### PR TITLE
overhaul campaign-init setup flow with a starter template picker

### DIFF
--- a/lib/actions/init.js
+++ b/lib/actions/init.js
@@ -2,6 +2,8 @@
 
 const fs = require('fs');
 const path = require('path');
+const https = require('https');
+const { execSync } = require('child_process');
 const logger = require('../logger');
 
 const D = '\x1b[90m';
@@ -21,21 +23,128 @@ const SCRIPTS = {
     'migrate': 'campaign-migrate',
 };
 
+const REPO = 'NextCommerceCo/campaign-cart-starter-templates';
+const REF = 'main';
+const TEMPLATES_URL = `https://raw.githubusercontent.com/${REPO}/${REF}/templates.json`;
+const CAMPAIGNS_URL = `https://raw.githubusercontent.com/${REPO}/${REF}/_data/campaigns.json`;
+const TARBALL_URL  = `https://codeload.github.com/${REPO}/tar.gz/refs/heads/${REF}`;
+
+function fetchBuffer(url, redirects = 5) {
+    return new Promise((resolve, reject) => {
+        https.get(url, (res) => {
+            if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+                res.resume();
+                if (redirects <= 0) return reject(new Error('too many redirects'));
+                return resolve(fetchBuffer(res.headers.location, redirects - 1));
+            }
+            if (res.statusCode !== 200) {
+                res.resume();
+                return reject(new Error(`HTTP ${res.statusCode} fetching ${url}`));
+            }
+            const chunks = [];
+            res.on('data', (c) => chunks.push(c));
+            res.on('end', () => resolve(Buffer.concat(chunks)));
+            res.on('error', reject);
+        }).on('error', reject);
+    });
+}
+
+async function fetchJson(url) {
+    const buf = await fetchBuffer(url);
+    return JSON.parse(buf.toString('utf8'));
+}
+
+// Extract a single template's src/<slug>/ subtree from the upstream tarball
+// using the system `tar` binary. No homemade parser, no truncation surprises.
+function extractTemplate(tarball, slug, destDir) {
+    const parent = path.dirname(destDir);
+    fs.mkdirSync(parent, { recursive: true });
+    const tmpDir = fs.mkdtempSync(path.join(parent, '.cpk-extract-'));
+    try {
+        execSync('tar -xz', { input: tarball, cwd: tmpDir, stdio: ['pipe', 'ignore', 'pipe'] });
+        const repoRoot = fs.readdirSync(tmpDir).find(d =>
+            fs.statSync(path.join(tmpDir, d)).isDirectory()
+        );
+        if (!repoRoot) throw new Error('tarball had no top-level directory');
+        const sourceDir = path.join(tmpDir, repoRoot, 'src', slug);
+        if (!fs.existsSync(sourceDir)) {
+            throw new Error(`upstream has no src/${slug}/`);
+        }
+        fs.cpSync(sourceDir, destDir, { recursive: true });
+        return countFiles(destDir);
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+}
+
+function countFiles(dir) {
+    let n = 0;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (entry.isDirectory()) n += countFiles(path.join(dir, entry.name));
+        else n++;
+    }
+    return n;
+}
+
+// Convert a free-form name into a valid campaign slug.
+function slugify(s) {
+    return String(s || '').toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+// Filter + sort a templates.json manifest into the order the picker shows.
+// Drops `hidden`, sorts by `priority` desc, name asc as tiebreak.
+function selectableTemplates(manifest) {
+    return (manifest && manifest.templates || [])
+        .filter(t => !t.hidden)
+        .sort((a, b) => {
+            const dp = (b.priority || 0) - (a.priority || 0);
+            return dp !== 0 ? dp : String(a.name || a.slug).localeCompare(String(b.name || b.slug));
+        });
+}
+
+// Produce the next state of `_data/campaigns.json` after merging an upstream
+// entry under `localSlug` and overriding the name with what the user provided.
+function mergeCampaignEntry(localCampaigns, localSlug, upstreamEntry, name) {
+    const base = upstreamEntry || { description: '' };
+    return { ...localCampaigns, [localSlug]: { ...base, name } };
+}
+
+// Merge missing CLI scripts into a package.json object. Returns
+// { pkg, added: [keys] }; does not mutate the input.
+function mergeScripts(pkg) {
+    const next = { ...pkg, scripts: { ...(pkg && pkg.scripts || {}) } };
+    const added = [];
+    for (const [k, v] of Object.entries(SCRIPTS)) {
+        if (!next.scripts[k]) {
+            next.scripts[k] = v;
+            added.push(k);
+        }
+    }
+    return { pkg: next, added };
+}
+
+// Apply an API key to a config.js source string. Returns the new string,
+// or null if no `apiKey:` field was found.
+function applyApiKey(configSource, apiKey) {
+    const updated = configSource.replace(/apiKey:\s*['"].*?['"]/, `apiKey: '${apiKey.trim()}'`);
+    return updated === configSource ? null : updated;
+}
+
 async function main() {
-    const { intro, log, outro } = await import('@clack/prompts');
+    const { intro, select, confirm, text, log, outro, isCancel, spinner } = await import('@clack/prompts');
 
     intro('Next Campaign Page Kit — init');
 
-    // package.json scripts
+    // 1. package.json scripts
     const packageJsonPath = path.join(process.cwd(), 'package.json');
     if (fs.existsSync(packageJsonPath)) {
-        const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-        pkg.scripts = pkg.scripts || {};
-        const missing = Object.entries(SCRIPTS).filter(([k]) => !pkg.scripts[k]);
-        if (missing.length > 0) {
-            missing.forEach(([k, v]) => { pkg.scripts[k] = v; });
+        const current = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+        const { pkg, added } = mergeScripts(current);
+        if (added.length > 0) {
             fs.writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n', 'utf8');
-            log.success(`added package.json scripts: ${D}${missing.map(([k]) => k).join(', ')}${R}`);
+            log.success(`added package.json scripts: ${D}${added.join(', ')}${R}`);
         } else {
             log.step('package.json scripts already present');
         }
@@ -43,7 +152,7 @@ async function main() {
         log.warn(`no package.json found — run ${D}npm init -y${R} first`);
     }
 
-    // _data/campaigns.json
+    // 2. _data/campaigns.json
     const campaignsDataPath = path.join(process.cwd(), '_data', 'campaigns.json');
     if (!fs.existsSync(campaignsDataPath)) {
         fs.mkdirSync(path.dirname(campaignsDataPath), { recursive: true });
@@ -53,10 +162,136 @@ async function main() {
         log.step('_data/campaigns.json already exists');
     }
 
-    outro(`Next steps:\n  1. Add campaigns to ${D}_data/campaigns.json${R}\n  2. Create ${D}src/{campaign-slug}/${R} with your campaign files\n  3. Run ${D}npm run dev${R} to start the dev server`);
+    // 3. fetch + show templates
+    let manifest;
+    try {
+        manifest = await fetchJson(TEMPLATES_URL);
+    } catch (err) {
+        log.warn(`could not fetch templates: ${err.message}`);
+        outro(`Run ${D}npm run dev${R} when ready.`);
+        return;
+    }
+
+    const templates = selectableTemplates(manifest);
+
+    if (templates.length === 0) {
+        outro(`Run ${D}npm run dev${R} when ready.`);
+        return;
+    }
+
+    const slug = await select({
+        message: 'Pick a starter template',
+        options: templates.map(t => ({
+            value: t.slug,
+            label: t.deprecated ? `[DEPRECATED] ${t.name}` : t.name,
+            hint: t.description || t.slug,
+        })),
+    });
+    if (isCancel(slug)) { outro('Cancelled.'); return; }
+    const picked = templates.find(t => t.slug === slug);
+
+    // 4a. campaign name (defaults to upstream template name)
+    const name = await text({
+        message: 'Campaign name',
+        placeholder: picked.name,
+        initialValue: picked.name,
+        validate: (v) => {
+            if (!(v || '').trim()) return 'name cannot be empty';
+        },
+    });
+    if (isCancel(name)) { outro('Cancelled.'); return; }
+    const finalName = name.trim();
+
+    // 4b. local slug (defaults to a slugified version of the name)
+    const defaultSlug = slugify(finalName) || slug;
+    const localSlug = await text({
+        message: 'Local campaign slug',
+        placeholder: defaultSlug,
+        initialValue: defaultSlug,
+        validate: (v) => {
+            const t = (v || '').trim();
+            if (!t) return 'slug cannot be empty';
+            if (!/^[a-z0-9][a-z0-9-]*$/.test(t)) return 'lowercase letters, digits, hyphens only';
+        },
+    });
+    if (isCancel(localSlug)) { outro('Cancelled.'); return; }
+    const finalSlug = localSlug.trim();
+
+    // 5. overwrite check
+    const destDir = path.join(process.cwd(), 'src', finalSlug);
+    if (fs.existsSync(destDir)) {
+        const ok = await confirm({ message: `src/${finalSlug}/ already exists. Overwrite?`, initialValue: false });
+        if (isCancel(ok) || !ok) { outro('Cancelled.'); return; }
+        fs.rmSync(destDir, { recursive: true, force: true });
+    }
+
+    // 6. download + extract
+    const sp = spinner();
+    sp.start(`Downloading ${slug}`);
+    try {
+        const tarball = await fetchBuffer(TARBALL_URL);
+        const written = extractTemplate(tarball, slug, destDir);
+        sp.stop(`Wrote ${written} files to src/${finalSlug}/`);
+    } catch (err) {
+        sp.stop('Download failed');
+        log.error(err.message);
+        outro('Template install failed.');
+        return;
+    }
+
+    // 7. merge upstream campaigns.json entry into local registry under finalSlug,
+    //    overriding name with what the user provided
+    try {
+        const upstream = await fetchJson(CAMPAIGNS_URL);
+        const local = JSON.parse(fs.readFileSync(campaignsDataPath, 'utf8'));
+        const next = mergeCampaignEntry(local, finalSlug, upstream[slug], finalName);
+        fs.writeFileSync(campaignsDataPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
+        log.success(`Registered ${D}${finalSlug}${R} in _data/campaigns.json`);
+    } catch (err) {
+        log.warn(`could not merge registry entry: ${err.message}`);
+    }
+
+    // 8. optional: set API key
+    const wantsKey = await confirm({ message: 'Set the Campaign API key now?', initialValue: true });
+    if (!isCancel(wantsKey) && wantsKey) {
+        const apiKey = await text({
+            message: 'API key',
+            placeholder: 'your-api-key',
+            validate: (v) => { if (!(v || '').trim()) return 'API key cannot be empty'; },
+        });
+        if (!isCancel(apiKey)) {
+            const configPath = path.join(destDir, 'assets', 'config.js');
+            try {
+                const updated = applyApiKey(fs.readFileSync(configPath, 'utf8'), apiKey);
+                if (updated === null) {
+                    log.warn(`no apiKey field found in assets/config.js — set it manually`);
+                } else {
+                    fs.writeFileSync(configPath, updated, 'utf8');
+                    log.success('API key written to assets/config.js');
+                }
+            } catch (err) {
+                log.warn(`could not write API key: ${err.message}`);
+            }
+        }
+    }
+
+    outro(`Next step: ${D}npm run dev${R} — preview ${finalSlug}`);
 }
 
-main().catch(err => {
-    logger.error(err.message);
-    process.exit(1);
-});
+if (require.main === module) {
+    main().catch(err => {
+        logger.error(err.message);
+        process.exit(1);
+    });
+}
+
+module.exports = {
+    SCRIPTS,
+    slugify,
+    selectableTemplates,
+    mergeCampaignEntry,
+    mergeScripts,
+    applyApiKey,
+    extractTemplate,
+    countFiles,
+};

--- a/lib/actions/init.js
+++ b/lib/actions/init.js
@@ -237,7 +237,7 @@ async function main() {
 
     // 4a. campaign name (defaults to upstream template name)
     const name = await text({
-        message: 'Campaign name',
+        message: `Campaign name ${D}(display name shown in your dev server picker)${R}`,
         placeholder: picked.name,
         initialValue: picked.name,
         validate: (v) => {
@@ -250,7 +250,7 @@ async function main() {
     // 4b. local slug (defaults to a slugified version of the name)
     const defaultSlug = slugify(finalName) || slug;
     const localSlug = await text({
-        message: 'Local campaign slug',
+        message: `Campaign slug ${D}(directory name under src/ and URL path: e.g. /my-campaign/)${R}`,
         placeholder: defaultSlug,
         initialValue: defaultSlug,
         validate: (v) => {
@@ -328,7 +328,7 @@ async function main() {
     const wantsKey = await confirm({ message: 'Set the Campaign API key now?', initialValue: true });
     if (!isCancel(wantsKey) && wantsKey) {
         const apiKey = await text({
-            message: 'API key',
+            message: `API key ${D}(from your store's Campaigns App — written to assets/config.js)${R}`,
             placeholder: 'your-api-key',
             validate: (v) => { if (!(v || '').trim()) return 'API key cannot be empty'; },
         });

--- a/lib/actions/init.js
+++ b/lib/actions/init.js
@@ -86,6 +86,51 @@ function countFiles(dir) {
     return n;
 }
 
+function replaceDirectoryWithRollback(stagedDir, destDir, commit) {
+    const parent = path.dirname(destDir);
+    const backupPrefix = path.join(parent, `.cpk-backup-${path.basename(destDir)}-`);
+    let backupDir = null;
+    let stagedMoved = false;
+    let committed = false;
+
+    try {
+        if (fs.existsSync(destDir)) {
+            backupDir = fs.mkdtempSync(backupPrefix);
+            fs.rmSync(backupDir, { recursive: true, force: true });
+            fs.renameSync(destDir, backupDir);
+        }
+
+        fs.renameSync(stagedDir, destDir);
+        stagedMoved = true;
+        commit();
+        committed = true;
+
+        if (backupDir) {
+            try {
+                fs.rmSync(backupDir, { recursive: true, force: true });
+            } catch {
+                // The install is already committed; avoid rolling back a valid install
+                // because cleanup of the rollback backup failed.
+            }
+        }
+    } catch (err) {
+        if (committed) {
+            throw err;
+        }
+        if (stagedMoved && fs.existsSync(destDir)) {
+            fs.rmSync(destDir, { recursive: true, force: true });
+        }
+        if (backupDir && fs.existsSync(backupDir) && !fs.existsSync(destDir)) {
+            fs.renameSync(backupDir, destDir);
+        }
+        throw err;
+    } finally {
+        if (!stagedMoved && fs.existsSync(stagedDir)) {
+            fs.rmSync(stagedDir, { recursive: true, force: true });
+        }
+    }
+}
+
 // Convert a free-form name into a valid campaign slug.
 function slugify(s) {
     return String(s || '').toLowerCase()
@@ -217,41 +262,69 @@ async function main() {
     if (isCancel(localSlug)) { outro('Cancelled.'); return; }
     const finalSlug = localSlug.trim();
 
-    // 5. overwrite check
+    // 5. read registries and check for conflicts before touching campaign files
     const destDir = path.join(process.cwd(), 'src', finalSlug);
-    if (fs.existsSync(destDir)) {
-        const ok = await confirm({ message: `src/${finalSlug}/ already exists. Overwrite?`, initialValue: false });
-        if (isCancel(ok) || !ok) { outro('Cancelled.'); return; }
-        fs.rmSync(destDir, { recursive: true, force: true });
-    }
-
-    // 6. download + extract
-    const sp = spinner();
-    sp.start(`Downloading ${slug}`);
+    let localCampaigns;
     try {
-        const tarball = await fetchBuffer(TARBALL_URL);
-        const written = extractTemplate(tarball, slug, destDir);
-        sp.stop(`Wrote ${written} files to src/${finalSlug}/`);
+        localCampaigns = JSON.parse(fs.readFileSync(campaignsDataPath, 'utf8'));
     } catch (err) {
-        sp.stop('Download failed');
-        log.error(err.message);
+        log.error(`could not read _data/campaigns.json: ${err.message}`);
         outro('Template install failed.');
         return;
     }
 
-    // 7. merge upstream campaigns.json entry into local registry under finalSlug,
-    //    overriding name with what the user provided
-    try {
-        const upstream = await fetchJson(CAMPAIGNS_URL);
-        const local = JSON.parse(fs.readFileSync(campaignsDataPath, 'utf8'));
-        const next = mergeCampaignEntry(local, finalSlug, upstream[slug], finalName);
-        fs.writeFileSync(campaignsDataPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
-        log.success(`Registered ${D}${finalSlug}${R} in _data/campaigns.json`);
-    } catch (err) {
-        log.warn(`could not merge registry entry: ${err.message}`);
+    const hasDirectory = fs.existsSync(destDir);
+    const hasRegistryEntry = Object.prototype.hasOwnProperty.call(localCampaigns, finalSlug);
+    if (hasDirectory || hasRegistryEntry) {
+        const conflicts = [];
+        if (hasDirectory) conflicts.push(`src/${finalSlug}/`);
+        if (hasRegistryEntry) conflicts.push(`_data/campaigns.json entry`);
+        const ok = await confirm({ message: `${conflicts.join(' and ')} already exists. Overwrite?`, initialValue: false });
+        if (isCancel(ok) || !ok) { outro('Cancelled.'); return; }
     }
 
-    // 8. optional: set API key
+    let upstreamEntry = null;
+    try {
+        const upstream = await fetchJson(CAMPAIGNS_URL);
+        upstreamEntry = upstream[slug] || null;
+        if (!upstreamEntry) {
+            log.warn(`upstream registry has no entry for ${slug}; using a minimal local entry`);
+        }
+    } catch (err) {
+        log.warn(`could not fetch upstream registry entry: ${err.message}; using a minimal local entry`);
+    }
+
+    const nextCampaigns = mergeCampaignEntry(localCampaigns, finalSlug, upstreamEntry, finalName);
+
+    // 6. download + extract to a staging directory, then replace atomically
+    const sp = spinner();
+    sp.start(`Downloading ${slug}`);
+    let stagingRoot;
+    try {
+        const destParent = path.dirname(destDir);
+        fs.mkdirSync(destParent, { recursive: true });
+        stagingRoot = fs.mkdtempSync(path.join(destParent, '.cpk-install-'));
+        const stagedDir = path.join(stagingRoot, finalSlug);
+        const tarball = await fetchBuffer(TARBALL_URL);
+        const written = extractTemplate(tarball, slug, stagedDir);
+        replaceDirectoryWithRollback(stagedDir, destDir, () => {
+            fs.writeFileSync(campaignsDataPath, JSON.stringify(nextCampaigns, null, 2) + '\n', 'utf8');
+        });
+        sp.stop(`Wrote ${written} files to src/${finalSlug}/`);
+    } catch (err) {
+        sp.stop('Template install failed');
+        log.error(err.message);
+        outro('Template install failed.');
+        return;
+    } finally {
+        if (stagingRoot) {
+            fs.rmSync(stagingRoot, { recursive: true, force: true });
+        }
+    }
+
+    log.success(`Registered ${D}${finalSlug}${R} in _data/campaigns.json`);
+
+    // 7. optional: set API key
     const wantsKey = await confirm({ message: 'Set the Campaign API key now?', initialValue: true });
     if (!isCancel(wantsKey) && wantsKey) {
         const apiKey = await text({
@@ -294,4 +367,5 @@ module.exports = {
     applyApiKey,
     extractTemplate,
     countFiles,
+    replaceDirectoryWithRollback,
 };

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -1,0 +1,250 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execSync } = require('child_process');
+
+const {
+    SCRIPTS,
+    slugify,
+    selectableTemplates,
+    mergeCampaignEntry,
+    mergeScripts,
+    applyApiKey,
+    extractTemplate,
+    countFiles,
+} = require('../lib/actions/init');
+
+// ---------------------------------------------------------------------------
+// slugify
+// ---------------------------------------------------------------------------
+
+test('slugify: lowercases and replaces non-alphanumerics with hyphens', () => {
+    assert.equal(slugify('My Campaign'), 'my-campaign');
+    assert.equal(slugify('Olympus MV — Two-step'), 'olympus-mv-two-step');
+});
+
+test('slugify: collapses repeats and trims leading/trailing hyphens', () => {
+    assert.equal(slugify('  -- Hello   World!! --'), 'hello-world');
+});
+
+test('slugify: returns empty string for empty/whitespace/non-alphanumeric input', () => {
+    assert.equal(slugify(''), '');
+    assert.equal(slugify('!!!'), '');
+    assert.equal(slugify(null), '');
+});
+
+// ---------------------------------------------------------------------------
+// selectableTemplates
+// ---------------------------------------------------------------------------
+
+test('selectableTemplates: filters out hidden entries', () => {
+    const result = selectableTemplates({
+        templates: [
+            { slug: 'a', name: 'A', priority: 50 },
+            { slug: 'b', name: 'B', priority: 50, hidden: true },
+        ],
+    });
+    assert.equal(result.length, 1);
+    assert.equal(result[0].slug, 'a');
+});
+
+test('selectableTemplates: sorts by priority desc, then name asc', () => {
+    const result = selectableTemplates({
+        templates: [
+            { slug: 'low',  name: 'Low',  priority: 10 },
+            { slug: 'top',  name: 'Top',  priority: 100 },
+            { slug: 'mid1', name: 'Mid B', priority: 50 },
+            { slug: 'mid2', name: 'Mid A', priority: 50 },
+        ],
+    });
+    assert.deepEqual(result.map(t => t.slug), ['top', 'mid2', 'mid1', 'low']);
+});
+
+test('selectableTemplates: treats missing priority as 0', () => {
+    const result = selectableTemplates({
+        templates: [
+            { slug: 'a', name: 'A', priority: 5 },
+            { slug: 'b', name: 'B' },
+        ],
+    });
+    assert.equal(result[0].slug, 'a');
+});
+
+test('selectableTemplates: tolerates missing manifest / templates', () => {
+    assert.deepEqual(selectableTemplates(null), []);
+    assert.deepEqual(selectableTemplates({}), []);
+    assert.deepEqual(selectableTemplates({ templates: [] }), []);
+});
+
+// ---------------------------------------------------------------------------
+// mergeCampaignEntry
+// ---------------------------------------------------------------------------
+
+test('mergeCampaignEntry: adds a slug while preserving existing entries', () => {
+    const next = mergeCampaignEntry(
+        { existing: { name: 'Existing' } },
+        'olympus',
+        { name: 'Olympus', sdk_version: '0.4.18', store_phone: '...' },
+        'My Olympus'
+    );
+    assert.deepEqual(next.existing, { name: 'Existing' });
+    assert.equal(next.olympus.name, 'My Olympus');
+    assert.equal(next.olympus.sdk_version, '0.4.18');
+    assert.equal(next.olympus.store_phone, '...');
+});
+
+test('mergeCampaignEntry: user-supplied name overrides upstream name', () => {
+    const next = mergeCampaignEntry({}, 'x', { name: 'Upstream', description: 'd' }, 'Custom');
+    assert.equal(next.x.name, 'Custom');
+    assert.equal(next.x.description, 'd');
+});
+
+test('mergeCampaignEntry: tolerates a null upstream entry', () => {
+    const next = mergeCampaignEntry({}, 'x', null, 'Custom');
+    assert.equal(next.x.name, 'Custom');
+    assert.equal(next.x.description, '');
+});
+
+test('mergeCampaignEntry: does not mutate the input', () => {
+    const local = { a: { name: 'A' } };
+    mergeCampaignEntry(local, 'b', { name: 'B' }, 'B!');
+    assert.deepEqual(local, { a: { name: 'A' } });
+});
+
+// ---------------------------------------------------------------------------
+// mergeScripts
+// ---------------------------------------------------------------------------
+
+test('mergeScripts: adds all CLI scripts to a fresh package.json', () => {
+    const { pkg, added } = mergeScripts({ name: 'demo' });
+    assert.equal(added.length, Object.keys(SCRIPTS).length);
+    for (const k of Object.keys(SCRIPTS)) {
+        assert.equal(pkg.scripts[k], SCRIPTS[k]);
+    }
+});
+
+test('mergeScripts: returns no additions when scripts are already present', () => {
+    const { added } = mergeScripts({ scripts: { ...SCRIPTS } });
+    assert.deepEqual(added, []);
+});
+
+test('mergeScripts: preserves user-customized scripts', () => {
+    const { pkg } = mergeScripts({ scripts: { dev: 'custom' } });
+    assert.equal(pkg.scripts.dev, 'custom');
+    assert.equal(pkg.scripts.build, SCRIPTS.build);
+});
+
+test('mergeScripts: does not mutate the input', () => {
+    const input = { scripts: { dev: 'custom' } };
+    mergeScripts(input);
+    assert.deepEqual(input, { scripts: { dev: 'custom' } });
+});
+
+// ---------------------------------------------------------------------------
+// applyApiKey
+// ---------------------------------------------------------------------------
+
+test('applyApiKey: replaces a single-quoted apiKey field', () => {
+    const out = applyApiKey("module.exports = { apiKey: '' };", 'abc');
+    assert.match(out, /apiKey: 'abc'/);
+});
+
+test('applyApiKey: replaces a double-quoted apiKey field', () => {
+    const out = applyApiKey('module.exports = { apiKey: "old" };', 'new');
+    assert.match(out, /apiKey: 'new'/);
+});
+
+test('applyApiKey: trims whitespace from the key', () => {
+    const out = applyApiKey("apiKey: ''", '  spaced  ');
+    assert.match(out, /apiKey: 'spaced'/);
+});
+
+test('applyApiKey: returns null when no apiKey field is present', () => {
+    assert.equal(applyApiKey('module.exports = { other: true };', 'k'), null);
+});
+
+// ---------------------------------------------------------------------------
+// extractTemplate (integration: real fixture tarball via system `tar`)
+// ---------------------------------------------------------------------------
+
+function buildFixtureTarball() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cpk-fixture-'));
+    const repoDir = path.join(root, 'fixture-repo-main');
+    const olympusDir = path.join(repoDir, 'src', 'olympus');
+    const limosDir = path.join(repoDir, 'src', 'limos');
+    fs.mkdirSync(path.join(olympusDir, '_layouts'), { recursive: true });
+    fs.mkdirSync(path.join(olympusDir, 'assets'), { recursive: true });
+    fs.mkdirSync(path.join(olympusDir, '_includes', 'landing'), { recursive: true });
+    fs.mkdirSync(limosDir, { recursive: true });
+    fs.writeFileSync(path.join(olympusDir, 'page.html'), '<h1>olympus</h1>');
+    fs.writeFileSync(path.join(olympusDir, '_layouts', 'base.html'), 'layout');
+    fs.writeFileSync(path.join(olympusDir, 'assets', 'config.js'), "apiKey: ''");
+    fs.writeFileSync(path.join(olympusDir, '_includes', 'landing', 'hero.html'), 'hero');
+    fs.writeFileSync(path.join(limosDir, 'page.html'), '<h1>limos</h1>');
+    fs.writeFileSync(path.join(repoDir, 'README.md'), 'readme');
+
+    const tarball = execSync('tar -czf - fixture-repo-main', { cwd: root });
+    fs.rmSync(root, { recursive: true, force: true });
+    return tarball;
+}
+
+test('extractTemplate: extracts only the requested slug, including deep _includes', () => {
+    const tarball = buildFixtureTarball();
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cpk-extract-test-'));
+    const dest = path.join(root, 'src', 'olympus');
+
+    const written = extractTemplate(tarball, 'olympus', dest);
+
+    assert.equal(written, 4);
+    assert.equal(fs.readFileSync(path.join(dest, 'page.html'), 'utf8'), '<h1>olympus</h1>');
+    assert.equal(fs.readFileSync(path.join(dest, '_layouts/base.html'), 'utf8'), 'layout');
+    assert.equal(fs.readFileSync(path.join(dest, '_includes/landing/hero.html'), 'utf8'), 'hero');
+    assert.equal(fs.existsSync(path.join(root, 'src', 'limos')), false);
+    assert.equal(fs.existsSync(path.join(dest, 'README.md')), false);
+
+    fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('extractTemplate: throws when the slug is missing from the tarball', () => {
+    const tarball = buildFixtureTarball();
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cpk-extract-test-'));
+
+    assert.throws(
+        () => extractTemplate(tarball, 'does-not-exist', path.join(root, 'src', 'x')),
+        /no src\/does-not-exist/
+    );
+
+    fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('extractTemplate: cleans up its temp dir on success', () => {
+    const tarball = buildFixtureTarball();
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cpk-extract-test-'));
+    const dest = path.join(root, 'src', 'olympus');
+
+    extractTemplate(tarball, 'olympus', dest);
+
+    const stragglers = fs.readdirSync(path.join(root, 'src')).filter(n => n.startsWith('.cpk-extract-'));
+    assert.deepEqual(stragglers, []);
+
+    fs.rmSync(root, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// countFiles
+// ---------------------------------------------------------------------------
+
+test('countFiles: counts files recursively, ignoring directories', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cpk-count-test-'));
+    fs.mkdirSync(path.join(root, 'a'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'a', 'b'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'top.txt'), '1');
+    fs.writeFileSync(path.join(root, 'a', 'mid.txt'), '2');
+    fs.writeFileSync(path.join(root, 'a', 'b', 'deep.txt'), '3');
+
+    assert.equal(countFiles(root), 3);
+
+    fs.rmSync(root, { recursive: true, force: true });
+});

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -14,6 +14,7 @@ const {
     applyApiKey,
     extractTemplate,
     countFiles,
+    replaceDirectoryWithRollback,
 } = require('../lib/actions/init');
 
 // ---------------------------------------------------------------------------
@@ -228,6 +229,77 @@ test('extractTemplate: cleans up its temp dir on success', () => {
 
     const stragglers = fs.readdirSync(path.join(root, 'src')).filter(n => n.startsWith('.cpk-extract-'));
     assert.deepEqual(stragglers, []);
+
+    fs.rmSync(root, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// replaceDirectoryWithRollback
+// ---------------------------------------------------------------------------
+
+test('replaceDirectoryWithRollback: replaces the destination and runs commit', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cpk-replace-test-'));
+    const dest = path.join(root, 'src', 'olympus');
+    const staged = path.join(root, 'src', '.cpk-install-abc', 'olympus');
+    const marker = path.join(root, 'committed');
+
+    fs.mkdirSync(dest, { recursive: true });
+    fs.writeFileSync(path.join(dest, 'old.html'), 'old');
+    fs.mkdirSync(staged, { recursive: true });
+    fs.writeFileSync(path.join(staged, 'new.html'), 'new');
+
+    replaceDirectoryWithRollback(staged, dest, () => {
+        fs.writeFileSync(marker, 'yes');
+    });
+
+    assert.equal(fs.existsSync(path.join(dest, 'old.html')), false);
+    assert.equal(fs.readFileSync(path.join(dest, 'new.html'), 'utf8'), 'new');
+    assert.equal(fs.readFileSync(marker, 'utf8'), 'yes');
+    assert.deepEqual(fs.readdirSync(path.dirname(dest)).filter(n => n.startsWith('.cpk-backup-')), []);
+
+    fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('replaceDirectoryWithRollback: restores an existing destination when commit fails', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cpk-replace-test-'));
+    const dest = path.join(root, 'src', 'olympus');
+    const staged = path.join(root, 'src', '.cpk-install-abc', 'olympus');
+
+    fs.mkdirSync(dest, { recursive: true });
+    fs.writeFileSync(path.join(dest, 'old.html'), 'old');
+    fs.mkdirSync(staged, { recursive: true });
+    fs.writeFileSync(path.join(staged, 'new.html'), 'new');
+
+    assert.throws(
+        () => replaceDirectoryWithRollback(staged, dest, () => {
+            throw new Error('registry write failed');
+        }),
+        /registry write failed/
+    );
+
+    assert.equal(fs.readFileSync(path.join(dest, 'old.html'), 'utf8'), 'old');
+    assert.equal(fs.existsSync(path.join(dest, 'new.html')), false);
+    assert.deepEqual(fs.readdirSync(path.dirname(dest)).filter(n => n.startsWith('.cpk-backup-')), []);
+
+    fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('replaceDirectoryWithRollback: removes a new destination when commit fails', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cpk-replace-test-'));
+    const dest = path.join(root, 'src', 'olympus');
+    const staged = path.join(root, 'src', '.cpk-install-abc', 'olympus');
+
+    fs.mkdirSync(staged, { recursive: true });
+    fs.writeFileSync(path.join(staged, 'new.html'), 'new');
+
+    assert.throws(
+        () => replaceDirectoryWithRollback(staged, dest, () => {
+            throw new Error('registry write failed');
+        }),
+        /registry write failed/
+    );
+
+    assert.equal(fs.existsSync(dest), false);
 
     fs.rmSync(root, { recursive: true, force: true });
 });


### PR DESCRIPTION
Overhaul the campaign-init function to pull a list of starter templates and streamline setting up a new template from a starter template. 