### PR TITLE
Add source-agnostic template fetching for private template families

### DIFF
--- a/lib/actions/init.js
+++ b/lib/actions/init.js
@@ -28,7 +28,11 @@ const SCRIPTS = {
 // resolveTemplateSource(overrides), where overrides come from the --source-* /
 // --private flags. The AI-context doc is family-agnostic page-kit guidance, so
 // it is always pulled from the public starter-templates repo (the default).
-const AI_CONTEXT_DOC_URL = resolveTemplateSource().ai_context_doc_url;
+// Resolved lazily (not at module load) so a future validation tightening can't
+// turn an import into a hard module-load failure.
+function aiContextDocUrl() {
+    return resolveTemplateSource().ai_context_doc_url;
+}
 
 // Exit codes — every error path maps to one of these. 0 is reserved for success.
 const EXIT = {
@@ -153,7 +157,11 @@ function fetchBufferAuthed(url, token, redirects = 5) {
                 // 302s to codeload.github.com — pinning the host hardens against a
                 // compromised/malicious upstream redirector pointing elsewhere.
                 if (!isTrustedGithubRedirect(res.headers.location)) {
-                    return reject(new Error(`refusing redirect to untrusted target: ${res.headers.location}`));
+                    // Report only the host, not the full (signed) redirect URL, so
+                    // it can't end up echoed into operator output or logs.
+                    let host;
+                    try { host = new URL(res.headers.location).host; } catch { host = '(unparseable)'; }
+                    return reject(new Error(`refusing redirect to untrusted host: ${host}`));
                 }
                 return resolve(fetchBuffer(res.headers.location, redirects - 1));
             }
@@ -184,12 +192,15 @@ function resolveGithubToken() {
     const env = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
     if (env && env.trim()) return env.trim();
     try {
-        const out = execSync('gh auth token', { stdio: ['ignore', 'pipe', 'ignore'] })
+        // timeout so a wedged gh (locked keyring, slow credential helper) can't
+        // hang campaign-init indefinitely — a timeout throws and is treated the
+        // same as "no token", yielding the actionable MISSING_GITHUB_TOKEN error.
+        const out = execSync('gh auth token', { stdio: ['ignore', 'pipe', 'ignore'], timeout: 5000 })
             .toString('utf8')
             .trim();
         if (out) return out;
     } catch {
-        // gh not installed / not authenticated — fall through to null.
+        // gh not installed / not authenticated / timed out — fall through to null.
     }
     return null;
 }
@@ -564,7 +575,7 @@ async function writeAiContext({ brandRoot, tool, keep, dryRun }) {
 
     let upstreamBody;
     try {
-        const buf = await fetchBuffer(AI_CONTEXT_DOC_URL);
+        const buf = await fetchBuffer(aiContextDocUrl());
         upstreamBody = buf.toString('utf8');
     } catch (err) {
         const wrapped = new Error(`could not fetch AI context doc: ${err.message}`);
@@ -1049,5 +1060,7 @@ module.exports = {
     buildAiContextContent,
     resolveGithubToken,
     isTrustedGithubRedirect,
+    fetchBuffer,
+    fetchBufferAuthed,
     main,
 };

--- a/lib/actions/init.js
+++ b/lib/actions/init.js
@@ -5,6 +5,7 @@ const path = require('path');
 const https = require('https');
 const { execSync } = require('child_process');
 const logger = require('../logger');
+const { resolveTemplateSource } = require('../template-source');
 
 const D = '\x1b[90m';
 const R = '\x1b[0m';
@@ -23,12 +24,11 @@ const SCRIPTS = {
     'migrate': 'campaign-migrate',
 };
 
-const REPO = 'NextCommerceCo/campaign-cart-starter-templates';
-const REF = 'main';
-const TEMPLATES_URL = `https://raw.githubusercontent.com/${REPO}/${REF}/templates.json`;
-const CAMPAIGNS_URL = `https://raw.githubusercontent.com/${REPO}/${REF}/_data/campaigns.json`;
-const TARBALL_URL  = `https://codeload.github.com/${REPO}/tar.gz/refs/heads/${REF}`;
-const AI_CONTEXT_DOC_URL = `https://raw.githubusercontent.com/${REPO}/${REF}/docs/campaign-page-kit-template-context.md`;
+// Source URLs (repo/ref/templates.json/tarball) are resolved at run time from
+// resolveTemplateSource(overrides), where overrides come from the --source-* /
+// --private flags. The AI-context doc is family-agnostic page-kit guidance, so
+// it is always pulled from the public starter-templates repo (the default).
+const AI_CONTEXT_DOC_URL = resolveTemplateSource().ai_context_doc_url;
 
 // Exit codes — every error path maps to one of these. 0 is reserved for success.
 const EXIT = {
@@ -65,6 +65,12 @@ const FLAG_SCHEMA = {
     'slug':             { type: 'string' },
     'name':             { type: 'string' },
     'api-key':          { type: 'string' },
+    // Source overrides — point at a non-default template repo/ref/subtree.
+    // --private marks it access-controlled (authenticated fetch + unlisted).
+    'source-repo':      { type: 'string' },
+    'source-ref':       { type: 'string' },
+    'source-path':      { type: 'string' },
+    'private':          { type: 'boolean' },
     'non-interactive':  { type: 'boolean' },
     'json':             { type: 'boolean' },
     'dry-run':          { type: 'boolean' },
@@ -104,13 +110,99 @@ async function fetchJson(url) {
     return JSON.parse(buf.toString('utf8'));
 }
 
+// Authenticated buffer fetch for private template repos. The initial request
+// carries the bearer token; GitHub's tarball endpoint (api.github.com/.../tarball)
+// 302-redirects to a short-lived signed codeload URL that must be fetched WITHOUT
+// the Authorization header — codeload rejects extra auth, and re-sending the
+// token cross-origin would leak it. So redirects fall through to the plain,
+// header-less fetchBuffer.
+// A redirect target is trusted only if it is https AND on a GitHub-owned host
+// (github.com / *.github.com / *.githubusercontent.com). Used to constrain where
+// an authenticated tarball fetch is allowed to follow a 302.
+function isTrustedGithubRedirect(location) {
+    let loc;
+    try {
+        loc = new URL(location);
+    } catch {
+        return false;
+    }
+    if (loc.protocol !== 'https:') return false;
+    const host = loc.hostname.toLowerCase();
+    return host === 'github.com'
+        || host.endsWith('.github.com')
+        || host.endsWith('.githubusercontent.com');
+}
+
+function fetchBufferAuthed(url, token, redirects = 5) {
+    return new Promise((resolve, reject) => {
+        const options = {
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'User-Agent': 'next-campaign-page-kit',
+                'Accept': 'application/vnd.github+json',
+                'X-GitHub-Api-Version': '2022-11-28',
+            },
+        };
+        https.get(url, options, (res) => {
+            if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+                res.resume();
+                if (redirects <= 0) return reject(new Error('too many redirects'));
+                // Only follow https redirects to a GitHub-owned host. Auth is
+                // already dropped here (the redirect is fetched by the header-less
+                // fetchBuffer), and api.github.com's tarball endpoint only ever
+                // 302s to codeload.github.com — pinning the host hardens against a
+                // compromised/malicious upstream redirector pointing elsewhere.
+                if (!isTrustedGithubRedirect(res.headers.location)) {
+                    return reject(new Error(`refusing redirect to untrusted target: ${res.headers.location}`));
+                }
+                return resolve(fetchBuffer(res.headers.location, redirects - 1));
+            }
+            if (res.statusCode !== 200) {
+                res.resume();
+                return reject(new Error(`HTTP ${res.statusCode} fetching ${url}`));
+            }
+            const chunks = [];
+            res.on('data', (c) => chunks.push(c));
+            res.on('end', () => resolve(Buffer.concat(chunks)));
+            res.on('error', reject);
+        }).on('error', reject);
+    });
+}
+
+async function fetchJsonAuthed(url, token) {
+    const buf = await fetchBufferAuthed(url, token);
+    return JSON.parse(buf.toString('utf8'));
+}
+
+// Resolve a GitHub token for private template sources: env first (CI/headless
+// agent runs), then `gh auth token` (local dev). Returns null if none found, so
+// callers can fail with a clear, actionable message.
+// SECURITY: the returned token is only ever used as an Authorization header for
+// the source fetch. Never write it into `result`, the emitted JSON, spinner
+// text, or any log line.
+function resolveGithubToken() {
+    const env = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+    if (env && env.trim()) return env.trim();
+    try {
+        const out = execSync('gh auth token', { stdio: ['ignore', 'pipe', 'ignore'] })
+            .toString('utf8')
+            .trim();
+        if (out) return out;
+    } catch {
+        // gh not installed / not authenticated — fall through to null.
+    }
+    return null;
+}
+
 // ---------------------------------------------------------------------------
 // Template extraction (tarball → directory)
 // ---------------------------------------------------------------------------
 
-// Extract a single template's src/<slug>/ subtree from the upstream tarball
-// using the system `tar` binary. No homemade parser, no truncation surprises.
-function extractTemplate(tarball, slug, destDir) {
+// Extract a single template's <sourcePath>/<slug>/ subtree from the upstream
+// tarball using the system `tar` binary. No homemade parser, no truncation
+// surprises. sourcePath comes from the template-source registry (default 'src')
+// so a family whose repo lays templates out under a different root still resolves.
+function extractTemplate(tarball, slug, destDir, sourcePath = 'src') {
     const parent = path.dirname(destDir);
     fs.mkdirSync(parent, { recursive: true });
     const tmpDir = fs.mkdtempSync(path.join(parent, '.cpk-extract-'));
@@ -120,9 +212,15 @@ function extractTemplate(tarball, slug, destDir) {
             fs.statSync(path.join(tmpDir, d)).isDirectory()
         );
         if (!repoRoot) throw new Error('tarball had no top-level directory');
-        const sourceDir = path.join(tmpDir, repoRoot, 'src', slug);
+        // sourcePath + slug are tarball-internal (POSIX) names, validated to be a
+        // relative, ".."-free, backslash-free subtree. Build the subtree with
+        // path.posix so the trust-boundary contract is platform-independent (a
+        // native path.join would treat "\" as a separator on Windows); then join
+        // it onto the native tmp dir for the real filesystem path.
+        const subtree = path.posix.join(sourcePath, slug);
+        const sourceDir = path.join(tmpDir, repoRoot, subtree);
         if (!fs.existsSync(sourceDir)) {
-            throw new Error(`upstream has no src/${slug}/`);
+            throw new Error(`upstream has no ${subtree}/`);
         }
         fs.cpSync(sourceDir, destDir, { recursive: true });
         return countFiles(destDir);
@@ -369,10 +467,20 @@ USAGE
   campaign-init --json [flags]              emit a single JSON object on stdout (suppresses UI + prompts)
 
 FLAGS
-  --template <slug>          starter template slug (must exist in upstream templates.json)
+  --template <slug>          starter template slug. For the default public source
+                             it must exist in templates.json (and shows in the
+                             picker). With --private it resolves by slug only.
   --slug <name>              local campaign slug (folder under src/, also URL path)
   --name <"Display Name">    campaign display name (defaults to upstream template name)
   --api-key <key>            Campaign Cart API key written to assets/config.js
+
+  Source overrides (default = public NextCommerceCo/campaign-cart-starter-templates):
+  --source-repo <owner/repo> fetch templates from this repo instead of the default
+  --source-ref <ref>         branch/tag/SHA to fetch (default: main)
+  --source-path <dir>        subtree holding per-slug template folders (default: src/)
+  --private                  source is access-controlled: fetch authenticated
+                             (GITHUB_TOKEN/GH_TOKEN or gh auth) and skip the public
+                             picker; requires --template
 
   --non-interactive          never prompt; missing required input exits with code 5
   --json                     machine-readable stdout; suppresses all human UI
@@ -556,53 +664,100 @@ async function main(argv = process.argv.slice(2)) {
         ui.log.step('_data/campaigns.json already exists');
     }
 
-    // 3. fetch templates.json -----------------------------------------------
-    let manifest;
-    try {
-        manifest = await fetchJson(TEMPLATES_URL);
-    } catch (err) {
-        return fail(EXIT.UPSTREAM_FETCH_FAILED, [{
-            code: 'UPSTREAM_FETCH_FAILED',
-            message: `could not fetch templates.json: ${err.message}`,
-        }]);
-    }
-    const templates = selectableTemplates(manifest);
-    if (templates.length === 0) {
-        return fail(EXIT.UPSTREAM_FETCH_FAILED, [{
-            code: 'UPSTREAM_FETCH_FAILED',
-            message: 'upstream templates.json had no selectable templates',
-        }]);
-    }
-
-    // 4. resolve template slug ----------------------------------------------
+    // 3-4. resolve template slug + source -----------------------------------
+    // Source is caller-driven, not family-driven: by default we fetch from the
+    // public starter-templates repo (anonymous). The --source-* / --private flags
+    // point at a different repo/ref/subtree — e.g. an outside, access-controlled
+    // family. A --private source is fetched authenticated and is NOT expected in
+    // any public templates.json, so it skips the picker and resolves only by an
+    // explicit --template slug. page-kit holds no per-family source knowledge.
     let templateSlug = flags.template;
-    if (templateSlug) {
-        if (!templates.find(t => t.slug === templateSlug)) {
-            return fail(EXIT.UPSTREAM_TEMPLATE_NOT_FOUND, [{
-                code: 'UPSTREAM_TEMPLATE_NOT_FOUND',
-                message: `template "${templateSlug}" not found in upstream templates.json`,
-                hint: `valid: ${templates.map(t => t.slug).join(', ')}`,
+    let source;
+    try {
+        source = resolveTemplateSource({
+            repo: flags.sourceRepo,
+            ref: flags.sourceRef,
+            source_path: flags.sourcePath,
+            private: flags.private,
+        });
+    } catch (err) {
+        // resolveTemplateSource validates --source-* shape (repo/ref/path) and
+        // throws INVALID_SOURCE on a malformed value (traversal, odd chars, etc.).
+        return fail(EXIT.INVALID_INPUT, [{ code: 'INVALID_SOURCE', message: err.message }]);
+    }
+    let token = null;
+    let pickedTemplate;
+
+    if (source.private) {
+        // Private sources are unlisted: an explicit --template slug is required
+        // (no picker), and a token is required to fetch the private tarball.
+        if (!templateSlug) {
+            return fail(EXIT.MISSING_INPUT, [{
+                code: 'MISSING_INPUT',
+                message: 'a --private source requires an explicit --template <slug> (private sources are not shown in the picker)',
             }]);
         }
-    } else if (nonInteractive) {
-        return fail(EXIT.MISSING_INPUT, [{
-            code: 'MISSING_INPUT',
-            message: '--template is required in --non-interactive mode',
-            hint: `valid: ${templates.map(t => t.slug).join(', ')}`,
-        }]);
+        token = resolveGithubToken();
+        if (!token) {
+            // A missing token is a missing precondition, not a fetch failure — no
+            // fetch was attempted. Exit 5 (MISSING_INPUT) is the contract for
+            // "scripted run lacks required input"; the code string stays specific
+            // so a caller can tell this apart from a missing --template.
+            return fail(EXIT.MISSING_INPUT, [{
+                code: 'MISSING_GITHUB_TOKEN',
+                message: `--private source ${source.repo} needs a GitHub token; set GITHUB_TOKEN/GH_TOKEN or run \`gh auth login\` to fetch it`,
+            }]);
+        }
+        // Synthetic descriptor. The display name defaults to the slug here, then
+        // is upgraded to the source repo's campaigns.json name after step 8 (when
+        // no explicit --name was passed) — see "refine display name" below.
+        pickedTemplate = { slug: templateSlug, name: templateSlug, description: `private template source (${source.repo})` };
     } else {
-        const picked = await ui.select({
-            message: 'Pick a starter template',
-            options: templates.map(t => ({
-                value: t.slug,
-                label: t.deprecated ? `[DEPRECATED] ${t.name}` : t.name,
-                hint: t.description || t.slug,
-            })),
-        });
-        if (ui.isCancel(picked)) { ui.outro('Cancelled.'); return EXIT.OK; }
-        templateSlug = picked;
+        let manifest;
+        try {
+            manifest = await fetchJson(source.templates_url);
+        } catch (err) {
+            return fail(EXIT.UPSTREAM_FETCH_FAILED, [{
+                code: 'UPSTREAM_FETCH_FAILED',
+                message: `could not fetch templates.json: ${err.message}`,
+            }]);
+        }
+        const templates = selectableTemplates(manifest);
+        if (templates.length === 0) {
+            return fail(EXIT.UPSTREAM_FETCH_FAILED, [{
+                code: 'UPSTREAM_FETCH_FAILED',
+                message: 'upstream templates.json had no selectable templates',
+            }]);
+        }
+
+        if (templateSlug) {
+            if (!templates.find(t => t.slug === templateSlug)) {
+                return fail(EXIT.UPSTREAM_TEMPLATE_NOT_FOUND, [{
+                    code: 'UPSTREAM_TEMPLATE_NOT_FOUND',
+                    message: `template "${templateSlug}" not found in upstream templates.json`,
+                    hint: `valid: ${templates.map(t => t.slug).join(', ')}`,
+                }]);
+            }
+        } else if (nonInteractive) {
+            return fail(EXIT.MISSING_INPUT, [{
+                code: 'MISSING_INPUT',
+                message: '--template is required in --non-interactive mode',
+                hint: `valid: ${templates.map(t => t.slug).join(', ')}`,
+            }]);
+        } else {
+            const picked = await ui.select({
+                message: 'Pick a starter template',
+                options: templates.map(t => ({
+                    value: t.slug,
+                    label: t.deprecated ? `[DEPRECATED] ${t.name}` : t.name,
+                    hint: t.description || t.slug,
+                })),
+            });
+            if (ui.isCancel(picked)) { ui.outro('Cancelled.'); return EXIT.OK; }
+            templateSlug = picked;
+        }
+        pickedTemplate = templates.find(t => t.slug === templateSlug);
     }
-    const pickedTemplate = templates.find(t => t.slug === templateSlug);
 
     // 5. resolve name -------------------------------------------------------
     let finalName = flags.name && String(flags.name).trim();
@@ -671,7 +826,9 @@ async function main(argv = process.argv.slice(2)) {
     // 8. fetch upstream registry entry (best effort) ------------------------
     let upstreamEntry = null;
     try {
-        const upstream = await fetchJson(CAMPAIGNS_URL);
+        const upstream = source.private
+            ? await fetchJsonAuthed(source.campaigns_url, token)
+            : await fetchJson(source.campaigns_url);
         upstreamEntry = upstream[templateSlug] || null;
         if (!upstreamEntry) {
             const msg = `upstream registry has no entry for ${templateSlug}; using a minimal local entry`;
@@ -682,6 +839,16 @@ async function main(argv = process.argv.slice(2)) {
         const msg = `could not fetch upstream registry entry: ${err.message}; using a minimal local entry`;
         result.warnings.push(msg);
         if (!json) ui.log.warn(msg);
+    }
+
+    // Refine display name: a --private source's synthetic descriptor defaults its
+    // name to the slug (it isn't in any public manifest). When the operator did
+    // not pass --name, prefer the source repo's campaigns.json name (e.g. a
+    // proper-cased title instead of the raw slug). finalSlug is already fixed, so
+    // this only affects the display name, never the directory/URL.
+    if (source.private && !flags.name && upstreamEntry && upstreamEntry.name) {
+        const upstreamName = String(upstreamEntry.name).trim();
+        if (upstreamName) finalName = upstreamName;
     }
 
     const nextCampaigns = mergeCampaignEntry(localCampaigns, finalSlug, upstreamEntry, finalName);
@@ -722,8 +889,13 @@ async function main(argv = process.argv.slice(2)) {
         fs.mkdirSync(destParent, { recursive: true });
         stagingRoot = fs.mkdtempSync(path.join(destParent, '.cpk-install-'));
         const stagedDir = path.join(stagingRoot, finalSlug);
-        const tarball = await fetchBuffer(TARBALL_URL);
-        const written = extractTemplate(tarball, templateSlug, stagedDir);
+        // Private families need an authenticated tarball (api.github.com tarball
+        // endpoint → signed redirect); public families use the anonymous
+        // codeload URL. fetchBufferAuthed drops the token on the signed redirect.
+        const tarball = source.private
+            ? await fetchBufferAuthed(source.tarball_url_authenticated, token)
+            : await fetchBuffer(source.tarball_url_anonymous);
+        const written = extractTemplate(tarball, templateSlug, stagedDir, source.source_path);
         replaceDirectoryWithRollback(stagedDir, destDir, () => {
             fs.writeFileSync(campaignsDataPath, JSON.stringify(nextCampaigns, null, 2) + '\n', 'utf8');
         });
@@ -875,5 +1047,7 @@ module.exports = {
     validateSlug,
     aiContextTarget,
     buildAiContextContent,
+    resolveGithubToken,
+    isTrustedGithubRedirect,
     main,
 };

--- a/lib/template-source.js
+++ b/lib/template-source.js
@@ -85,15 +85,20 @@ function resolveTemplateSource(overrides = {}) {
         private: isPrivate,
         templates_url: `${rawBase(repo, ref)}/templates.json`,
         campaigns_url: `${rawBase(repo, ref)}/_data/campaigns.json`,
-        // Authenticated tarball (private sources): GitHub's API tarball endpoint
-        // honors an Authorization header and 302-redirects to a signed codeload
-        // URL. Named explicitly so a caller can't reach for it on a public source
-        // and accidentally make an authenticated request — public sources use
+        // Both tarball URLs take a PLAIN ref (branch, tag, or SHA) so they behave
+        // identically — no "refs/heads/" prefix, which the api.github.com endpoint
+        // rejects (404) and which the codeload form only honors for branches.
+        // Authenticated (private sources): GitHub's API tarball endpoint honors an
+        // Authorization header and 302-redirects to a signed codeload URL. Named
+        // explicitly so a caller can't reach for it on a public source and
+        // accidentally make an authenticated request — public sources use
         // tarball_url_anonymous below.
         tarball_url_authenticated: `https://api.github.com/repos/${repo}/tarball/${ref}`,
         // Anonymous codeload tarball (public sources).
-        tarball_url_anonymous: `https://codeload.github.com/${repo}/tar.gz/refs/heads/${ref}`,
-        ai_context_doc_url: `${rawBase(repo, ref)}/docs/campaign-page-kit-template-context.md`,
+        tarball_url_anonymous: `https://codeload.github.com/${repo}/tar.gz/${ref}`,
+        // The AI-context doc is family-agnostic page-kit guidance; always resolve
+        // it from the PUBLIC default so it is never a 404 for a private source.
+        ai_context_doc_url: `${rawBase(DEFAULT_SOURCE.repo, DEFAULT_SOURCE.ref)}/docs/campaign-page-kit-template-context.md`,
     };
 }
 

--- a/lib/template-source.js
+++ b/lib/template-source.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const path = require('path');
+
+// Resolve WHERE to fetch a starter-template's source.
+//
+// page-kit is source-agnostic. By default it fetches public families from the
+// public Campaign Cart starter-templates repo, anonymously. A caller — an
+// operator, or an orchestrator such as campaigns-os — can point `campaign-init`
+// at a DIFFERENT repo/ref/subtree and mark it private (an outside, access-
+// controlled template family) by passing --source-repo / --source-ref /
+// --source-path / --private.
+//
+// This module holds NO per-family knowledge: which family lives in which repo,
+// and whether it is private, is the caller's concern — never page-kit's. That
+// keeps the build tool generic and the opinionated family→source mapping in the
+// layer that owns it.
+
+// The default: public Campaign Cart starter templates, fetched anonymously.
+const DEFAULT_SOURCE = Object.freeze({
+    repo: 'NextCommerceCo/campaign-cart-starter-templates',
+    ref: 'main',
+    // Directory under the repo root that holds per-slug template folders. The
+    // family subtree extracted from the tarball is `${source_path}<slug>/`.
+    source_path: 'src/',
+    private: false,
+});
+
+function rawBase(repo, ref) {
+    return `https://raw.githubusercontent.com/${repo}/${ref}`;
+}
+
+function pickString(value, fallback) {
+    return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function invalidSource(message) {
+    const error = new Error(message);
+    error.code = 'INVALID_SOURCE';
+    return error;
+}
+
+// This module is the trust boundary where caller-supplied source values meet URL
+// construction and tarball extraction, so validate shape here (defense in depth
+// — a programmatic caller bypassing the CLI is covered too). Throws INVALID_SOURCE
+// on a malformed value.
+//   - repo: strict "owner/repo" (no traversal, no query strings / odd chars).
+//   - ref:  branch/tag/SHA; slashes allowed (feature/foo, refs/heads/x) but no
+//           "..", no leading/trailing slash, no odd chars.
+//   - source_path: a relative subtree only — reject "..", absolute, or "~" so
+//           extractTemplate can never path.join its way out of the tarball tree.
+function assertValidSource(repo, ref, source_path) {
+    if (!/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(repo) || repo.includes('..')) {
+        throw invalidSource(`invalid source repo "${repo}" — expected "owner/repo"`);
+    }
+    if (!/^[A-Za-z0-9._/-]+$/.test(ref) || ref.includes('..') || ref.startsWith('/') || ref.endsWith('/')) {
+        throw invalidSource(`invalid source ref "${ref}"`);
+    }
+    // source_path is a POSIX subtree (tar entries use "/"). Reject backslashes so
+    // the contract is platform-independent — otherwise a "src\\foo" would pass the
+    // POSIX checks here but be reinterpreted as a separator by path.win32.join.
+    const normalized = path.posix.normalize(source_path);
+    if (source_path.includes('..') || source_path.includes('\0') || source_path.includes('\\') || source_path.startsWith('~')
+        || normalized.startsWith('..') || path.posix.isAbsolute(normalized)) {
+        throw invalidSource(`invalid source path "${source_path}" — must be a relative POSIX subtree (forward slashes only, no ".." segments)`);
+    }
+}
+
+// Resolve a source descriptor (repo/ref/path/private + the concrete fetch URLs)
+// by overlaying caller-supplied overrides on the public default. `overrides` is
+// the shape produced from the CLI flags: { repo, ref, source_path, private }.
+// Any unset field falls back to the public default — so resolveTemplateSource()
+// with no argument is exactly the public starter-templates source.
+function resolveTemplateSource(overrides = {}) {
+    const o = overrides || {};
+    const repo = pickString(o.repo, DEFAULT_SOURCE.repo);
+    const ref = pickString(o.ref, DEFAULT_SOURCE.ref);
+    const source_path = pickString(o.source_path, DEFAULT_SOURCE.source_path);
+    const isPrivate = o.private == null ? DEFAULT_SOURCE.private : !!o.private;
+    assertValidSource(repo, ref, source_path);
+    return {
+        repo,
+        ref,
+        source_path,
+        private: isPrivate,
+        templates_url: `${rawBase(repo, ref)}/templates.json`,
+        campaigns_url: `${rawBase(repo, ref)}/_data/campaigns.json`,
+        // Authenticated tarball (private sources): GitHub's API tarball endpoint
+        // honors an Authorization header and 302-redirects to a signed codeload
+        // URL. Named explicitly so a caller can't reach for it on a public source
+        // and accidentally make an authenticated request — public sources use
+        // tarball_url_anonymous below.
+        tarball_url_authenticated: `https://api.github.com/repos/${repo}/tarball/${ref}`,
+        // Anonymous codeload tarball (public sources).
+        tarball_url_anonymous: `https://codeload.github.com/${repo}/tar.gz/refs/heads/${ref}`,
+        ai_context_doc_url: `${rawBase(repo, ref)}/docs/campaign-page-kit-template-context.md`,
+    };
+}
+
+module.exports = {
+    DEFAULT_SOURCE,
+    resolveTemplateSource,
+};

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -24,6 +24,7 @@ const {
     aiContextTarget,
     buildAiContextContent,
     isTrustedGithubRedirect,
+    fetchBufferAuthed,
 } = require('../lib/actions/init');
 
 // ---------------------------------------------------------------------------
@@ -43,6 +44,45 @@ test('isTrustedGithubRedirect: rejects non-https, foreign hosts, and look-alikes
     assert.equal(isTrustedGithubRedirect('https://github.com.attacker.io/x'), false);  // suffix look-alike
     assert.equal(isTrustedGithubRedirect('https://notgithub.com/x'), false);
     assert.equal(isTrustedGithubRedirect('not a url'), false);
+});
+
+// End-to-end: the authed fetch must DROP the Authorization header when it follows
+// the signed 302 to codeload — the whole reason fetchBufferAuthed exists. Mock the
+// shared https.get and assert the redirect request carries no token.
+test('fetchBufferAuthed drops the Authorization header on redirect', async () => {
+    const https = require('https');
+    const { EventEmitter } = require('events');
+    const original = https.get;
+    const calls = [];
+    https.get = (url, optionsOrCb, maybeCb) => {
+        const options = typeof optionsOrCb === 'function' ? {} : (optionsOrCb || {});
+        const cb = typeof optionsOrCb === 'function' ? optionsOrCb : maybeCb;
+        calls.push({ url: String(url), headers: options.headers || {} });
+        const res = new EventEmitter();
+        res.resume = () => {};
+        if (calls.length === 1) {
+            res.statusCode = 302;
+            res.headers = { location: 'https://codeload.github.com/o/r/tar.gz/main' };
+            process.nextTick(() => cb(res));
+        } else {
+            res.statusCode = 200;
+            res.headers = {};
+            process.nextTick(() => {
+                cb(res);
+                process.nextTick(() => { res.emit('data', Buffer.from('ok')); res.emit('end'); });
+            });
+        }
+        return { on: () => {} }; // .on('error', …) is chained but never fires here
+    };
+    try {
+        const buf = await fetchBufferAuthed('https://api.github.com/repos/o/r/tarball/main', 'secret-token');
+        assert.equal(buf.toString(), 'ok');
+        assert.equal(calls.length, 2, 'made the initial request + followed the redirect');
+        assert.equal(calls[0].headers.Authorization, 'Bearer secret-token', 'initial request carries the token');
+        assert.equal(calls[1].headers.Authorization, undefined, 'redirect request drops the token');
+    } finally {
+        https.get = original;
+    }
 });
 
 // ---------------------------------------------------------------------------

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -23,7 +23,27 @@ const {
     validateSlug,
     aiContextTarget,
     buildAiContextContent,
+    isTrustedGithubRedirect,
 } = require('../lib/actions/init');
+
+// ---------------------------------------------------------------------------
+// isTrustedGithubRedirect — authed-tarball redirect host pinning
+// ---------------------------------------------------------------------------
+
+test('isTrustedGithubRedirect: allows https GitHub-owned hosts', () => {
+    assert.equal(isTrustedGithubRedirect('https://codeload.github.com/o/r/tar.gz/x'), true);
+    assert.equal(isTrustedGithubRedirect('https://api.github.com/repos/o/r/tarball/main'), true);
+    assert.equal(isTrustedGithubRedirect('https://objects.githubusercontent.com/abc'), true);
+    assert.equal(isTrustedGithubRedirect('https://github.com/o/r'), true);
+});
+
+test('isTrustedGithubRedirect: rejects non-https, foreign hosts, and look-alikes', () => {
+    assert.equal(isTrustedGithubRedirect('http://codeload.github.com/x'), false);      // downgrade
+    assert.equal(isTrustedGithubRedirect('https://attacker.example/x'), false);        // foreign host
+    assert.equal(isTrustedGithubRedirect('https://github.com.attacker.io/x'), false);  // suffix look-alike
+    assert.equal(isTrustedGithubRedirect('https://notgithub.com/x'), false);
+    assert.equal(isTrustedGithubRedirect('not a url'), false);
+});
 
 // ---------------------------------------------------------------------------
 // slugify

--- a/test/template-source.test.js
+++ b/test/template-source.test.js
@@ -1,0 +1,91 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { DEFAULT_SOURCE, resolveTemplateSource } = require('../lib/template-source');
+
+// ---------------------------------------------------------------------------
+// resolveTemplateSource — public default (no overrides)
+// ---------------------------------------------------------------------------
+
+test('resolveTemplateSource: no overrides resolves to the public default', () => {
+    for (const overrides of [undefined, null, {}, { repo: '   ' }]) {
+        const src = resolveTemplateSource(overrides);
+        assert.equal(src.repo, DEFAULT_SOURCE.repo);
+        assert.equal(src.ref, DEFAULT_SOURCE.ref);
+        assert.equal(src.source_path, 'src/');
+        assert.equal(src.private, false);
+        assert.match(src.templates_url, /raw\.githubusercontent\.com\/NextCommerceCo\/campaign-cart-starter-templates\/main\/templates\.json$/);
+        assert.match(src.tarball_url_anonymous, /codeload\.github\.com\/NextCommerceCo\/campaign-cart-starter-templates\/tar\.gz\/refs\/heads\/main$/);
+    }
+});
+
+// ---------------------------------------------------------------------------
+// resolveTemplateSource — caller-supplied overrides (the agnostic mechanism)
+// ---------------------------------------------------------------------------
+
+test('resolveTemplateSource: applies repo/ref/path overrides and builds matching URLs', () => {
+    const src = resolveTemplateSource({ repo: 'example-org/private-templates', ref: 'release', source_path: 'families/' });
+    assert.equal(src.repo, 'example-org/private-templates');
+    assert.equal(src.ref, 'release');
+    assert.equal(src.source_path, 'families/');
+    assert.match(src.templates_url, /example-org\/private-templates\/release\/templates\.json$/);
+    assert.match(src.campaigns_url, /example-org\/private-templates\/release\/_data\/campaigns\.json$/);
+    assert.match(src.tarball_url_anonymous, /codeload\.github\.com\/example-org\/private-templates\/tar\.gz\/refs\/heads\/release$/);
+});
+
+test('resolveTemplateSource: --private marks the source private + exposes the authed tarball', () => {
+    const src = resolveTemplateSource({ repo: 'example-org/private-templates', private: true });
+    assert.equal(src.private, true);
+    // Authenticated tarball uses the api.github.com endpoint (honors a token).
+    assert.match(src.tarball_url_authenticated, /api\.github\.com\/repos\/example-org\/private-templates\/tarball\/main$/);
+});
+
+test('resolveTemplateSource: unset override fields fall back to the public default', () => {
+    const src = resolveTemplateSource({ private: true }); // repo/ref/path omitted
+    assert.equal(src.repo, DEFAULT_SOURCE.repo);
+    assert.equal(src.ref, DEFAULT_SOURCE.ref);
+    assert.equal(src.source_path, DEFAULT_SOURCE.source_path);
+    assert.equal(src.private, true);
+});
+
+test('resolveTemplateSource: holds no per-family knowledge (a bare slug is not a private trigger)', () => {
+    // Passing a family-ish object with no `private` resolves PUBLIC — privateness
+    // is an explicit caller decision, never inferred from a name.
+    const src = resolveTemplateSource({ repo: 'example-org/anything' });
+    assert.equal(src.private, false);
+});
+
+// ---------------------------------------------------------------------------
+// resolveTemplateSource — input validation (trust boundary)
+// ---------------------------------------------------------------------------
+
+test('resolveTemplateSource: rejects malformed source repo', () => {
+    for (const repo of ['../../etc/passwd', 'owner/repo?token=leak', 'owner', 'a/b/c', 'owner/..', 'own er/repo']) {
+        assert.throws(() => resolveTemplateSource({ repo }), /invalid source repo/, `should reject ${repo}`);
+    }
+});
+
+test('resolveTemplateSource: rejects path-traversal / absolute / backslash source_path', () => {
+    for (const source_path of ['../../', '..', '/etc', '~/x', 'a/../../b', 'src\\foo', 'src\\..\\etc']) {
+        assert.throws(() => resolveTemplateSource({ source_path }), /invalid source path/, `should reject ${JSON.stringify(source_path)}`);
+    }
+});
+
+test('resolveTemplateSource: rejects traversal / bad chars in ref', () => {
+    for (const ref of ['../evil', '/main', 'main/', 'a b', 'a;b']) {
+        assert.throws(() => resolveTemplateSource({ ref }), /invalid source ref/, `should reject ${ref}`);
+    }
+});
+
+test('resolveTemplateSource: accepts legitimate shapes (slashed refs, nested subtrees)', () => {
+    assert.doesNotThrow(() => resolveTemplateSource({ repo: 'Some-Org/private-templates.v2', ref: 'feature/foo', source_path: 'families/checkout/' }));
+    assert.doesNotThrow(() => resolveTemplateSource({ ref: 'refs/heads/main' }));
+    assert.doesNotThrow(() => resolveTemplateSource()); // defaults must always pass
+});
+
+test('DEFAULT_SOURCE is frozen', () => {
+    assert.equal(Object.isFrozen(DEFAULT_SOURCE), true);
+    const before = DEFAULT_SOURCE.repo;
+    try { DEFAULT_SOURCE.repo = 'evil/repo'; } catch { /* strict-mode throw is fine too */ }
+    assert.equal(DEFAULT_SOURCE.repo, before);
+});

--- a/test/template-source.test.js
+++ b/test/template-source.test.js
@@ -15,7 +15,7 @@ test('resolveTemplateSource: no overrides resolves to the public default', () =>
         assert.equal(src.source_path, 'src/');
         assert.equal(src.private, false);
         assert.match(src.templates_url, /raw\.githubusercontent\.com\/NextCommerceCo\/campaign-cart-starter-templates\/main\/templates\.json$/);
-        assert.match(src.tarball_url_anonymous, /codeload\.github\.com\/NextCommerceCo\/campaign-cart-starter-templates\/tar\.gz\/refs\/heads\/main$/);
+        assert.match(src.tarball_url_anonymous, /codeload\.github\.com\/NextCommerceCo\/campaign-cart-starter-templates\/tar\.gz\/main$/);
     }
 });
 
@@ -30,7 +30,7 @@ test('resolveTemplateSource: applies repo/ref/path overrides and builds matching
     assert.equal(src.source_path, 'families/');
     assert.match(src.templates_url, /example-org\/private-templates\/release\/templates\.json$/);
     assert.match(src.campaigns_url, /example-org\/private-templates\/release\/_data\/campaigns\.json$/);
-    assert.match(src.tarball_url_anonymous, /codeload\.github\.com\/example-org\/private-templates\/tar\.gz\/refs\/heads\/release$/);
+    assert.match(src.tarball_url_anonymous, /codeload\.github\.com\/example-org\/private-templates\/tar\.gz\/release$/);
 });
 
 test('resolveTemplateSource: --private marks the source private + exposes the authed tarball', () => {
@@ -38,6 +38,9 @@ test('resolveTemplateSource: --private marks the source private + exposes the au
     assert.equal(src.private, true);
     // Authenticated tarball uses the api.github.com endpoint (honors a token).
     assert.match(src.tarball_url_authenticated, /api\.github\.com\/repos\/example-org\/private-templates\/tarball\/main$/);
+    // The AI-context doc always points at the PUBLIC default, never the private
+    // source (raw.githubusercontent.com would 404 for a private repo).
+    assert.match(src.ai_context_doc_url, /raw\.githubusercontent\.com\/NextCommerceCo\/campaign-cart-starter-templates\/main\/docs\//);
 });
 
 test('resolveTemplateSource: unset override fields fall back to the public default', () => {
@@ -77,10 +80,17 @@ test('resolveTemplateSource: rejects traversal / bad chars in ref', () => {
     }
 });
 
-test('resolveTemplateSource: accepts legitimate shapes (slashed refs, nested subtrees)', () => {
+test('resolveTemplateSource: accepts legitimate shapes (branches, tags, SHAs, nested subtrees)', () => {
     assert.doesNotThrow(() => resolveTemplateSource({ repo: 'Some-Org/private-templates.v2', ref: 'feature/foo', source_path: 'families/checkout/' }));
-    assert.doesNotThrow(() => resolveTemplateSource({ ref: 'refs/heads/main' }));
+    assert.doesNotThrow(() => resolveTemplateSource({ ref: 'v1.2.3' }));                                  // tag
+    assert.doesNotThrow(() => resolveTemplateSource({ ref: '0123456789abcdef0123456789abcdef01234567' })); // SHA
     assert.doesNotThrow(() => resolveTemplateSource()); // defaults must always pass
+});
+
+test('resolveTemplateSource: both tarball URLs take a plain ref (no refs/heads/ prefix)', () => {
+    const src = resolveTemplateSource({ repo: 'o/r', ref: 'v2.0.0' });
+    assert.match(src.tarball_url_anonymous, /\/tar\.gz\/v2\.0\.0$/);
+    assert.match(src.tarball_url_authenticated, /\/tarball\/v2\.0\.0$/);
 });
 
 test('DEFAULT_SOURCE is frozen', () => {


### PR DESCRIPTION
## What

`campaign-init` fetched starter-template source from one hardcoded public repo, so it couldn't scaffold template families hosted elsewhere (e.g. an outside, access-controlled repo). This adds a **source-agnostic** resolver + authenticated fetch — while keeping page-kit a generic build tool that holds **no per-family knowledge**.

## Design

- **`lib/template-source.js`** (new) — `resolveTemplateSource(overrides)` overlays caller-supplied `{repo, ref, source_path, private}` on the public starter-templates default. Names no families, no private repos. As the trust boundary it validates shape (`INVALID_SOURCE` on bad repo / ref / traversing or non-POSIX `source_path`).
- **`lib/actions/init.js`** — new `--source-repo / --source-ref / --source-path / --private` flags.
  - Default (no flags): public starter-templates, anonymous — **unchanged behavior**.
  - `--private`: authenticated tarball (`GITHUB_TOKEN`/`GH_TOKEN` or `gh auth token`), skips the public picker, requires `--template`. Token dropped on the signed redirect (pinned to https + GitHub-owned hosts), never serialized.
  - Missing token → exit 5; malformed `--source-*` → exit 6.
  - `extractTemplate` honors `source_path` via `path.posix.join` (platform-independent), instead of hardcoding `src/`.

The opinionated part — *which* family lives in *which* private repo — stays in the orchestrating layer (campaigns-os / the operator's invocation), never in page-kit.

## Verification
- `--template <slug> --source-repo <owner/repo> --private` → authenticated extract; name refined from `campaigns.json`.
- `--private` without a token → exit 5; bad `--source-path` → exit 6.
- Public `--template <slug>` with no flags → anonymous (unchanged).
- **208 tests** green.

---
Supersedes **#19** — identical net change, but presented as one clean commit instead of #19's build-then-refactor history. Pairs with campaigns-os#101 (the Arjuna recognition contracts; repo-agnostic).